### PR TITLE
Add move measure method

### DIFF
--- a/lib/openstudio/analysis/workflow.rb
+++ b/lib/openstudio/analysis/workflow.rb
@@ -184,6 +184,29 @@ module OpenStudio
       end
       alias find_workflow_step find_measure
 
+      # Move a measure by its name to after another measure by its name, 
+      # error if there is no measure with the name. If no after measure
+      # name is passed, then it will be at the beginning
+      #
+      # @params measure_name [String] instance name of the measure
+      # @params after_measure_name [String] instance name of the measure to move after
+      def move_measure_after(measure_name, after_measure_name=nil)
+        measure = self.find_measure(measure_name)
+        raise "Could not find measure with name #{measure_name}" unless measure
+
+        if after_measure_name.nil?
+          # put the measure at the beginning
+          @items.insert(0, @items.delete(measure))
+        else
+          after_measure = self.find_measure(after_measure_name)
+          raise "Could not find measure with name #{after_measure_name}" unless after_measure
+
+          # the index will be the index of the after measure plus 1 or the len of the list
+          idx = [@items.index(after_measure)+1, @items.length-1].min
+          @items.insert(idx, @items.delete(measure))
+        end
+      end
+        
       # Return all the variables in the analysis as an array. The list that is returned is read only.
       #
       # @return [Array] All variables in the workflow

--- a/spec/openstudio/workflow_spec.rb
+++ b/spec/openstudio/workflow_spec.rb
@@ -62,6 +62,41 @@ describe OpenStudio::Analysis::Workflow do
     expect(m.name).to eq 'thermostat_2'
   end
 
+  it 'should find move a workflow step to after a named step' do
+    @w.clear
+
+    p = 'spec/files/measures/SetThermostatSchedules'
+    m1 = @w.add_measure_from_path('thermostat_1', 'thermostat', p)
+    m2 = @w.add_measure_from_path('thermostat_2', 'thermostat 2', p)
+    m3 = @w.add_measure_from_path('thermostat_3', 'thermostat 3', p)
+    m4 = @w.add_measure_from_path('thermostat_4', 'thermostat 4', p)
+
+    measure_names = @w.measures.map(&:name)
+    expect(measure_names).to eq ['thermostat_1', 'thermostat_2', 'thermostat_3', 'thermostat_4']
+    # find the index where the measure is in the workflow
+    @w.move_measure_after('thermostat_4', 'thermostat_2')
+    # @w.measures.insert(@w.measures.index(m2), @w.measures.delete_at(@w.measures.index(m4)))
+    # should return thermostat, thermostat_2, thermostat_4, thermostat_3
+
+    measure_names = @w.measures.map(&:name)
+    expect(measure_names).to eq ['thermostat_1', 'thermostat_2', 'thermostat_4',  'thermostat_3']
+
+    # now move it to the end
+    @w.move_measure_after('thermostat_4', 'thermostat_3')
+    measure_names = @w.measures.map(&:name)
+    expect(measure_names).to eq ['thermostat_1', 'thermostat_2', 'thermostat_3', 'thermostat_4']
+    
+    # now move it to the beginning -- do not say the after measure
+    @w.move_measure_after('thermostat_4')
+    measure_names = @w.measures.map(&:name)
+    expect(measure_names).to eq ['thermostat_4', 'thermostat_1', 'thermostat_2', 'thermostat_3']
+    
+    # TODO: verify that errors are thrown when measures do not exist
+    
+  end
+
+
+
   it 'should find a workflow step and make a variable' do
     @w.clear
 


### PR DESCRIPTION
This adds a simple method to move a measure after a problem formulation has been created. 