### PR TITLE
Upgrade to latest github checkout

### DIFF
--- a/.github/workflows/openstudio-analysis.yml
+++ b/.github/workflows/openstudio-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: ruby-install
       shell: bash
       run: "sudo apt install -y ruby && ruby -v" # ruby anye tests here when ready 
@@ -18,7 +18,7 @@ jobs:
     steps:
     -
       name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     -
       name: Display system info
       run: |


### PR DESCRIPTION
GitHub action cleanup.... resolves this issue:

![image](https://github.com/NREL/OpenStudio-analysis-gem/assets/1907354/9148a328-799d-4cf0-937b-fcdda8528b21)
